### PR TITLE
Contentfulの改行内容を反映させたい

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,6 +35,11 @@ module.exports = {
 						import(`remark-gfm`)
 					]
 				},
+				gatsbyRemarkPlugins: [
+					{
+						resolve: `gatsby-remark-line-breaks`
+					}
+				]
 			},
 		},
 		`gatsby-plugin-image`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "gatsby": "^5.9.0",
         "gatsby-plugin-image": "^3.10.0",
         "gatsby-plugin-mdx": "^3.20.0",
+        "gatsby-remark-line-breaks": "^1.0.0",
         "gatsby-source-contentful": "^8.9.1",
         "gatsby-transformer-remark": "^6.9.0",
         "react": "^18.2.0",
@@ -10352,6 +10353,14 @@
         "react-dom": "^18.0.0 || ^0.0.0"
       }
     },
+    "node_modules/gatsby-remark-line-breaks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-line-breaks/-/gatsby-remark-line-breaks-1.0.0.tgz",
+      "integrity": "sha512-chLmEttxDDLGy18nhOlfPFDmzt8EhLEnj1RSxvdtskpIS8F0M3vIhRN9J1MFB5s+19OeLzscubrjT+kK4gKrgw==",
+      "dependencies": {
+        "remark-breaks": "^1.0.5"
+      }
+    },
     "node_modules/gatsby-script": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/gatsby-script/-/gatsby-script-2.9.0.tgz",
@@ -17473,6 +17482,15 @@
         "remark-stringify": "^9.0.0",
         "unified": "^9.1.0"
       },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-1.0.5.tgz",
+      "integrity": "sha512-lr8+TlJI273NjEqL27eUthPYPTCgXEj4NaLbnazS3bQaQL2FySlsbtgo52gE36fE1gWeQgkn1VdmWsoT+uA7FA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -28589,6 +28607,14 @@
         "prop-types": "^15.8.1"
       }
     },
+    "gatsby-remark-line-breaks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-line-breaks/-/gatsby-remark-line-breaks-1.0.0.tgz",
+      "integrity": "sha512-chLmEttxDDLGy18nhOlfPFDmzt8EhLEnj1RSxvdtskpIS8F0M3vIhRN9J1MFB5s+19OeLzscubrjT+kK4gKrgw==",
+      "requires": {
+        "remark-breaks": "^1.0.5"
+      }
+    },
     "gatsby-script": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/gatsby-script/-/gatsby-script-2.9.0.tgz",
@@ -33406,6 +33432,11 @@
         "remark-stringify": "^9.0.0",
         "unified": "^9.1.0"
       }
+    },
+    "remark-breaks": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-1.0.5.tgz",
+      "integrity": "sha512-lr8+TlJI273NjEqL27eUthPYPTCgXEj4NaLbnazS3bQaQL2FySlsbtgo52gE36fE1gWeQgkn1VdmWsoT+uA7FA=="
     },
     "remark-footnotes": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gatsby": "^5.9.0",
     "gatsby-plugin-image": "^3.10.0",
     "gatsby-plugin-mdx": "^3.20.0",
+    "gatsby-remark-line-breaks": "^1.0.0",
     "gatsby-source-contentful": "^8.9.1",
     "gatsby-transformer-remark": "^6.9.0",
     "react": "^18.2.0",


### PR DESCRIPTION
- #10 
- `gatsbyRemarkPlugins`に`gatsby-remark-line-breaks`を追加する形
- ローカル環境では動作確認済み